### PR TITLE
Add badge checks after debt reduction

### DIFF
--- a/internal/discord/handlers/button_handlers.go
+++ b/internal/discord/handlers/button_handlers.go
@@ -711,6 +711,8 @@ func handleVerifyPaymentConfirmButton(s *discordgo.Session, i *discordgo.Interac
 			respondWithError(s, i, "ไม่สามารถอัปเดตข้อมูลหนี้สินในระบบได้")
 			return
 		}
+		CheckAndAwardBadges(s, debtorDiscordID, i.ChannelID)
+		CheckAndAwardBadges(s, creditorDiscordID, i.ChannelID)
 	}
 
 	// Respond to the creditor with confirmation

--- a/internal/discord/handlers/modal_handlers.go
+++ b/internal/discord/handlers/modal_handlers.go
@@ -88,6 +88,8 @@ func handlePayDebtModalSubmit(s *discordgo.Session, i *discordgo.InteractionCrea
 			respondWithError(s, i, fmt.Sprintf("เกิดข้อผิดพลาดในการประมวลผลการชำระเงิน: %v", err))
 			return
 		}
+		CheckAndAwardBadges(s, debtorDiscordID, i.ChannelID)
+		CheckAndAwardBadges(s, creditorDiscordID, i.ChannelID)
 	} else {
 		// If payment amount closely matches unpaid total, mark those transactions as paid
 		if paymentAmount >= unpaidTotal*0.99 && paymentAmount <= unpaidTotal*1.01 {
@@ -104,6 +106,8 @@ func handlePayDebtModalSubmit(s *discordgo.Session, i *discordgo.InteractionCrea
 				respondWithError(s, i, fmt.Sprintf("เกิดข้อผิดพลาดในการประมวลผลการชำระเงิน: %v", err))
 				return
 			}
+			CheckAndAwardBadges(s, debtorDiscordID, i.ChannelID)
+			CheckAndAwardBadges(s, creditorDiscordID, i.ChannelID)
 		}
 	}
 

--- a/internal/discord/handlers/slip_verification.go
+++ b/internal/discord/handlers/slip_verification.go
@@ -164,6 +164,8 @@ func HandleSlipVerification(s *discordgo.Session, m *discordgo.MessageCreate) {
 			log.Printf("SlipVerify: Failed general debt reduction for %s to %s (%.2f): %v", debtorDiscordID, intendedPayeeDiscordID, amount, errReduce)
 			return
 		}
+		CheckAndAwardBadges(s, debtorDiscordID, m.ChannelID)
+		CheckAndAwardBadges(s, intendedPayeeDiscordID, m.ChannelID)
 		s.ChannelMessageSend(m.ChannelID, fmt.Sprintf(
 			"✅ สลิปได้รับการยืนยัน & ยอดหนี้สินจาก <@%s> ถึง <@%s> ลดลง %.2f บาท!\n- ผู้ส่ง (สลิป): %s (%s)\n- ผู้รับ (สลิป): %s (%s)\n- วันที่ (สลิป): %s\n- เลขอ้างอิง (สลิป): %s",
 			debtorDiscordID, intendedPayeeDiscordID, amount,


### PR DESCRIPTION
## Summary
- trigger badge eligibility checks when settling debts manually or via slip verification

## Testing
- `go vet ./...` *(fails: fetching modules forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68410feba53c832d95ec27fec610174e